### PR TITLE
docs: add CNAME and site_url

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.g-track.eu

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: GTrack Docs
 site_description: "Единый портал документации GTrack"
+site_url: https://docs.g-track.eu/
 docs_dir: docs
 nav:
   - Обзор: index.md


### PR DESCRIPTION
## Summary
- add a CNAME file pointing to docs.g-track.eu
- set the canonical site URL in MkDocs configuration

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d0849ad2fc832ebf1f9787bd674bc3