### PR TITLE
docs(ci): offline PyPI + auto-nav for /import + self-check

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -2,7 +2,6 @@ name: Docs - Deploy
 on:
   push:
     branches: [ main ]
-
 permissions:
   contents: read
   pages: write
@@ -31,13 +30,17 @@ jobs:
         run: |
           WCOUNT=$(ls -1 docs/vendor/wheels/*.whl 2>/dev/null | wc -l | tr -d ' ')
           LSIZE=$(test -f docs/requirements.lock.txt && wc -c < docs/requirements.lock.txt | tr -d ' ' || echo 0)
+          echo "wheel_count=$WCOUNT" >> $GITHUB_OUTPUT
+          echo "lock_size=$LSIZE" >> $GITHUB_OUTPUT
           if [ "$WCOUNT" -gt 0 ] && [ "$LSIZE" -gt 0 ]; then
             echo "ready=true" >> $GITHUB_OUTPUT
+            echo "Wheelhouse OK ($WCOUNT wheels), lock size $LSIZE"
           else
             echo "ready=false" >> $GITHUB_OUTPUT
+            echo "::notice ::Skipping build: wheels=$WCOUNT, lock_size=$LSIZE (main)"
           fi
 
-      - name: Install docs deps (OFFLINE from wheelhouse)
+      - name: Install docs deps (OFFLINE)
         if: steps.guard.outputs.ready == 'true'
         env:
           PIP_NO_INDEX: "1"
@@ -46,6 +49,15 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install --no-index --find-links docs/vendor/wheels -r docs/requirements.lock.txt
+          python - <<'PY'
+          import mkdocs, mkdocs_material, mkdocs_awesome_pages_plugin as ap
+          import mkdocs_git_revision_date_localized_plugin as gdl
+          import pymdownx
+          print("mkdocs", getattr(mkdocs, "__version__", "?"))
+          print("material", getattr(mkdocs_material, "__version__", "?"))
+          print("awesome-pages", getattr(ap, "__version__", "?"))
+          print("git-date-localized", getattr(gdl, "__version__", "?"))
+          PY
 
       - name: Build (strict)
         if: steps.guard.outputs.ready == 'true'
@@ -62,11 +74,13 @@ jobs:
           path: ./site
 
   deploy:
-    needs: build
-    if: needs.build.outputs.ready != 'false'
+    if: needs.build.outputs.ready == 'true'
     environment:
       name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    needs: build
     steps:
       - name: Deploy to GitHub Pages
+        id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,4 +1,4 @@
-name: Docs - Preview
+name: check-docs
 on:
   pull_request:
     branches: [ main ]
@@ -24,13 +24,17 @@ jobs:
         run: |
           WCOUNT=$(ls -1 docs/vendor/wheels/*.whl 2>/dev/null | wc -l | tr -d ' ')
           LSIZE=$(test -f docs/requirements.lock.txt && wc -c < docs/requirements.lock.txt | tr -d ' ' || echo 0)
+          echo "wheel_count=$WCOUNT" >> $GITHUB_OUTPUT
+          echo "lock_size=$LSIZE" >> $GITHUB_OUTPUT
           if [ "$WCOUNT" -gt 0 ] && [ "$LSIZE" -gt 0 ]; then
             echo "ready=true" >> $GITHUB_OUTPUT
+            echo "Wheelhouse OK ($WCOUNT wheels), lock size $LSIZE"
           else
             echo "ready=false" >> $GITHUB_OUTPUT
+            echo "::notice ::Skipping build: wheels=$WCOUNT, lock_size=$LSIZE"
           fi
 
-      - name: Install docs deps (OFFLINE from wheelhouse)
+      - name: Install docs deps (OFFLINE from wheelhouse) + print versions
         if: steps.guard.outputs.ready == 'true'
         env:
           PIP_NO_INDEX: "1"
@@ -39,12 +43,28 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install --no-index --find-links docs/vendor/wheels -r docs/requirements.lock.txt
-          python -c "import mkdocs; print('mkdocs', mkdocs.__version__)"
+          python - <<'PY'
+          import importlib, pkgutil, sys
+          mods = [
+            ("mkdocs", "mkdocs"),
+            ("material", "mkdocs_material"),
+            ("awesome-pages", "mkdocs_awesome_pages_plugin"),
+            ("git-date-localized", "mkdocs_git_revision_date_localized_plugin"),
+            ("pymdown-extensions", "pymdownx")
+          ]
+          for name, module in mods:
+            try:
+              m = importlib.import_module(module)
+              ver = getattr(m, "__version__", None)
+              print(f"[OK] {name}: {ver or 'version ?'} (module {module})")
+            except Exception as e:
+              print(f"[MISS] {name} (module {module}) -> {e}"); sys.exit(2)
+          PY
 
       - name: Build docs (strict)
         if: steps.guard.outputs.ready == 'true'
         run: python -m mkdocs build --strict
 
-      - name: Skip build (wheelhouse not ready yet)
+      - name: Skip build (wheelhouse/lock not ready yet)
         if: steps.guard.outputs.ready != 'true'
-        run: echo "::notice title=Docs build skipped::Wheelhouse/lock not ready yet. Merge infra PR and run 'Docs - Refresh Wheels'."
+        run: echo "::notice title=Docs build skipped::Wheelhouse пустой или lock отсутствует. Это ожидаемо для первого PR."

--- a/.github/workflows/docs-refresh-wheels.yml
+++ b/.github/workflows/docs-refresh-wheels.yml
@@ -7,7 +7,7 @@ on:
         required: false
         default: "3.11"
   schedule:
-    - cron: "0 6 1 * *"  # ежемесячно в 06:00 UTC первого числа
+    - cron: "0 6 1 * *"
 
 permissions:
   contents: write
@@ -56,7 +56,7 @@ jobs:
             echo "::warning title=Wheel missing::Falling back to sdist for some packages"
             python -m pip download -r docs/requirements.lock.txt -d docs/vendor/wheels
           fi
-          ls -1 docs/vendor/wheels | head -n 50
+          ls -1 docs/vendor/wheels | head -n 80
 
       - name: Sanity-check offline install & build
         run: |
@@ -66,7 +66,7 @@ jobs:
           python -c "import mkdocs; print('mkdocs OK', mkdocs.__version__)"
           python -m mkdocs build --strict
 
-      - name: Configure git for Actions (safe + token)
+      - name: Configure git for Actions
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -79,11 +79,12 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: "ci/docs-refresh-wheels"
+          branch: "codex/docs-refresh-wheels"
           branch-suffix: timestamp
           add-paths: |
             docs/requirements.lock.txt
             docs/vendor/wheels/**
+          signoff: true
           commit-message: |
             docs(ci): refresh wheelhouse & lock for offline PyPI
 
@@ -93,5 +94,5 @@ jobs:
             - Updated `docs/requirements.lock.txt` (pip-tools with hashes)
             - Downloaded wheels to `docs/vendor/wheels/`
             - Verified offline install and `python -m mkdocs build --strict`
-            **Docs updated.**
-          signoff: true
+
+            **Next:** Merge this PR. Then /import/ auto-appears in nav as soon as files land in docs/import/.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Документация — Changelog
 
+## docs-v2.8.2 — Offline PyPI + Auto-Nav for /import
+- CI: офлайн-установка зависимостей из `docs/vendor/wheels`
+- Новый чек `check-docs` с выводом версий плагинов
+- Автонавигация для `docs/import/**` (awesome-pages + .pages)
+- Добавлена страница `ops/CI/offline-pip.md`, обновлён `mkdocs.yml`
+
 ## docs-v2.8.1 — Offline PyPI for Docs (wheelhouse)
 - CI: офлайн-установка зависимостей из `docs/vendor/wheels`
 - Новый workflow `Docs - Refresh Wheels` (ручной + ежемесячный)

--- a/docs/import/.pages
+++ b/docs/import/.pages
@@ -1,0 +1,3 @@
+title: Imported docs
+collapse_single_pages: true
+sort_type: natural

--- a/docs/ops/CI/offline-pip.md
+++ b/docs/ops/CI/offline-pip.md
@@ -1,20 +1,16 @@
-# Offline PyPI для документации (wheelhouse)
+# Offline PyPI + автонавигация для `import/`
 
 ## Зачем
-CI/окружения иногда блокируют PyPI/CDN. Чтобы сборка доков не падала, зависимости ставим офлайн из `docs/vendor/wheels/`.
+PyPI/CDN могут быть заблокированы. Мы ставим зависимости **офлайн** из `docs/vendor/wheels/`, а раздел `import/` автоматически попадает в меню.
 
 ## Как работает
-- Декларации: `docs/requirements.in`
-- Лок: `docs/requirements.lock.txt` (с hash)
-- Колёса: `docs/vendor/wheels/`
+- `docs/requirements.in` → `docs/requirements.lock.txt` (точные версии с hashes)
+- Колёса: `docs/vendor/wheels/*.whl`
 - В CI: `pip install --no-index --find-links=docs/vendor/wheels -r docs/requirements.lock.txt`
+- Навигацию для `docs/import/**` строит плагин **awesome-pages** (файл `.pages` управляет заголовком/сортировкой).
 
 ## Обновление зависимостей
-Запусти workflow **Docs - Refresh Wheels** (ручной/по расписанию) — он:
-1) пересоберёт lock с hash,
-2) скачает колёса в `docs/vendor/wheels/`,
-3) проверит офлайн-установку и `mkdocs build --strict`,
-4) создаст PR.
+Запускайте **Docs - Refresh Wheels** (ручной/ежемесячный). Он пересобирает lock, скачивает колёса, валидирует офлайн-сборку и открывает PR.
 
 ## Локально
 ```bash
@@ -23,6 +19,6 @@ pip install --no-index --find-links=docs/vendor/wheels -r docs/requirements.lock
 python -m mkdocs serve
 ```
 
-Политика
-- Любое изменение mkdocs.yml/плагинов → запуск Docs - Refresh Wheels.
-- В PR — блок “Docs updated”.
+## Примечание по `import/`
+
+Новые файлы в `docs/import/` автоматически появятся в меню без правки `mkdocs.yml`. Для тонкой настройки структуры используйте `docs/import/.pages`.

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -9,5 +9,5 @@ mkdocs-git-revision-date-localized-plugin>=1.2,<2
 # Markdown extensions
 pymdown-extensions>=10.7,<11
 
-# Tooling
+# Tooling (safe)
 click>=8,<9

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,15 @@
 site_name: G-Track Docs
 theme:
   name: material
+  features:
+    - navigation.indexes
 
 plugins:
   - search
+  - awesome-pages
+  - git-revision-date-localized:
+      type: date
+      fallback_to_build_date: true
 
 extra_css:
   - stylesheets/layout.css
@@ -18,8 +24,8 @@ nav:
       - Обзор: spec/index.md
       - API v0 (ReDoc): spec/redoc/v0.md
       - API v1 (ReDoc, DRAFT): spec/redoc/v1.md
-  - Imported:
-      - Обзор: import/index.md
   - Ops:
       - CI:
           - Offline PyPI: ops/CI/offline-pip.md
+  - Import:
+      - import/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-# Do not edit directly; edit docs/requirements.in and run the "Docs - Refresh Wheels" workflow.
+# Do not edit directly — edit docs/requirements.in and run the "Docs - Refresh Wheels" workflow.
 -r docs/requirements.lock.txt


### PR DESCRIPTION
## Summary
- ensure docs workflows install from the local wheelhouse, expose guard messaging, and print dependency versions.
- add an automated "Docs - Refresh Wheels" workflow for compiling the lockfile and downloading wheels offline.
- update MkDocs configuration and docs content for awesome-pages auto navigation and offline PyPI guidance.

Next steps:
1) Run Actions → “Docs - Refresh Wheels” on branch main (once).
2) Merge the PR it creates (“Docs: refresh wheelhouse & lock…”).
3) Verify that “Docs - Deploy” installs from --no-index/--find-links and /import/ shows content when files appear.

Docs updated.

------
https://chatgpt.com/codex/tasks/task_e_68d3cf77c290832e97e8f6cc4c1c01e7