### PR TITLE
Add Docs - Verify Offline workflow

### DIFF
--- a/.github/workflows/docs-verify-offline.yml
+++ b/.github/workflows/docs-verify-offline.yml
@@ -1,0 +1,96 @@
+name: Docs - Verify Offline
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1"   # по понедельникам, 06:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # 0) Нет ли онлайн-установки из *.in в workflow?
+      - name: Ensure no online installs from requirements.in
+        run: |
+          set -euo pipefail
+          if grep -R --line-number -E "pip +install.+requirements\.in" .github/workflows || true; then
+            echo "::error title=Online install from .in detected::Workflows must install from lock via wheelhouse only."
+            exit 2
+          fi
+          echo "OK: workflows do not install from *.in"
+
+      # 1) Guard: есть ли lock и колёса?
+      - name: Detect wheelhouse/lock
+        id: guard
+        run: |
+          WCOUNT=$(ls -1 docs/vendor/wheels/*.whl 2>/dev/null | wc -l | tr -d ' ')
+          LSIZE=$(test -f docs/requirements.lock.txt && wc -c < docs/requirements.lock.txt | tr -d ' ' || echo 0)
+          echo "wheel_count=$WCOUNT" >> $GITHUB_OUTPUT
+          echo "lock_size=$LSIZE"   >> $GITHUB_OUTPUT
+          echo "Wheelhouse: $WCOUNT wheels, lock size: $LSIZE bytes"
+          [ "$WCOUNT" -gt 0 ] && [ "$LSIZE" -gt 0 ] || { echo "::error title=Offline assets missing::Run 'Docs - Refresh Wheels' first."; exit 2; }
+
+      # 2) Оффлайн-установка и проверка модулей
+      - name: Offline install (lock + wheelhouse) and plugin versions
+        env:
+          PIP_NO_INDEX: "1"
+          PIP_FIND_LINKS: "docs/vendor/wheels"
+          PIP_DISABLE_PIP_VERSION_CHECK: "1"
+        run: |
+          python -m pip install -U pip
+          python -m pip install --no-index --find-links docs/vendor/wheels -r docs/requirements.lock.txt
+          python - <<'PY'
+          import importlib, sys
+          modules = [
+            ("mkdocs", "mkdocs"),
+            ("material", "mkdocs_material"),
+            ("awesome-pages", "mkdocs_awesome_pages_plugin"),
+            ("git-date-localized", "mkdocs_git_revision_date_localized_plugin"),
+            ("pymdown-extensions", "pymdownx"),
+          ]
+          missing = []
+          for label, mod in modules:
+            try:
+              m = importlib.import_module(mod)
+              ver = getattr(m, "__version__", "?")
+              print(f"[OK] {label}: {ver}")
+            except Exception as e:
+              missing.append((label, mod, str(e)))
+          if missing:
+            print("Missing modules:", missing)
+            sys.exit(2)
+          PY
+
+      # 3) mkdocs.yml должен включать awesome-pages
+      - name: Check mkdocs.yml has 'awesome-pages' plugin
+        run: |
+          grep -q "awesome-pages" mkdocs.yml || { echo "::error title=mkdocs.yml::Plugin 'awesome-pages' not found in plugins."; sed -n '1,200p' mkdocs.yml; exit 2; }
+          echo "OK: mkdocs.yml includes awesome-pages"
+
+      # 4) Smoke-тест автонавигации: временно добавляем файл в docs/import/
+      - name: Auto-nav smoke file
+        run: |
+          mkdir -p docs/import
+          echo -e "# Auto-Nav Smoke\n\nThis page is created by CI to verify awesome-pages + import/." > docs/import/__autonav_smoke.md
+          ls -l docs/import
+
+      # 5) Строгая сборка и проверка, что страница появилась в site/
+      - name: Build (strict) and assert smoke page exists
+        run: |
+          python -m mkdocs build --strict -v
+          test -f site/import/__autonav_smoke/index.html || { echo "::error title=Auto-Nav failed::site/import/__autonav_smoke/index.html not found"; exit 2; }
+          echo "OK: Auto-Nav smoke page rendered"
+
+      # 6) Итог
+      - name: Summary
+        run: echo "✅ Offline install verified, plugins present, auto-nav for /import/ works."

--- a/docs/ops/CI/offline-verify.md
+++ b/docs/ops/CI/offline-verify.md
@@ -1,0 +1,11 @@
+# Проверка офлайн-сборки и автонавигации
+
+**Как запустить:** GitHub → **Actions → Docs - Verify Offline → Run workflow**.
+
+Проверяется:
+- офлайн-установка зависимостей из `docs/vendor/wheels` по `docs/requirements.lock.txt`,
+- наличие плагинов `mkdocs-material`, `mkdocs-awesome-pages-plugin`, `mkdocs-git-revision-date-localized`,
+- наличие `awesome-pages` в `mkdocs.yml`,
+- автонавигация для `docs/import/**`: временно создаётся файл `__autonav_smoke.md` и проверяется его появление в `site/import/__autonav_smoke/index.html`.
+
+Если тест падает с сообщением *Offline assets missing* — сперва запустите **Docs - Refresh Wheels**.


### PR DESCRIPTION
## Summary
- add a scheduled/workflow-dispatch GitHub Action to verify offline docs builds and awesome-pages auto-nav
- document the offline verification workflow under ops/CI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3d578a560832eb217430ea053b8f0