### PR TITLE
Fix ReDoc spec URLs to relative paths

### DIFF
--- a/.github/workflows/docs-verify-offline.yml
+++ b/.github/workflows/docs-verify-offline.yml
@@ -95,6 +95,11 @@ jobs:
           test -f site/import/__autonav_smoke/index.html || { echo "::error title=Auto-Nav failed::site/import/__autonav_smoke/index.html not found"; exit 2; }
           echo "OK: Auto-Nav smoke page rendered"
 
+      - name: Assert ReDoc spec files exist (no 404)
+        run: |
+          test -f site/spec/api/gtrack-v0.yaml || { echo "::error title=Missing spec::site/spec/api/gtrack-v0.yaml not found"; exit 2; }
+          test -f site/spec/api/gtrack-v1.yaml || { echo "::error title=Missing spec::site/spec/api/gtrack-v1.yaml not found"; exit 2; }
+
       # 6) Итог
       - name: Summary
         run: echo "✅ Offline install verified, plugins present, auto-nav for /import/ works."

--- a/docs/spec/redoc/v0.md
+++ b/docs/spec/redoc/v0.md
@@ -12,7 +12,7 @@ hide:
 
 <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
 <script>
-  const SPEC_URL = new URL('../api/gtrack-v0.yaml', window.location.origin).href;
+  const SPEC_URL = '../api/gtrack-v0.yaml';
   Redoc.init(SPEC_URL, { expandResponses: "200,201,204" }, document.getElementById('redoc-v0'));
 </script>
 

--- a/docs/spec/redoc/v1.md
+++ b/docs/spec/redoc/v1.md
@@ -13,7 +13,7 @@ hide:
 
 <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
 <script>
-  const SPEC_URL = new URL('../api/gtrack-v1.yaml', window.location.origin).href;
+  const SPEC_URL = '../api/gtrack-v1.yaml';
   Redoc.init(SPEC_URL, { expandResponses: "200,201,204" }, document.getElementById('redoc-v1'));
 </script>
 


### PR DESCRIPTION
## Summary
- update the ReDoc v0 and v1 pages to reference their specs via relative paths
- add a CI guard step ensuring the built ReDoc spec files are present

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d945d4f4ac832e8b6c5ad11eeef5cd