### PR TITLE
Enable manual docs deploy trigger

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -2,6 +2,11 @@ name: Docs - Deploy
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why deploy?"
+        required: false
 permissions:
   contents: read
   pages: write

--- a/docs/.redeploy
+++ b/docs/.redeploy
@@ -1,0 +1,1 @@
+touch to redeploy


### PR DESCRIPTION
## Summary
- allow the docs deploy workflow to be run manually with an optional reason input
- add a no-op redeploy marker file so merges trigger a new deployment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9484b55b0832ea0461ad12c6a257f