### PR TITLE
docs(redoc): fix spec URLs to be root-relative-safe (respect Material <base href>)

### DIFF
--- a/docs/spec/redoc/v0.md
+++ b/docs/spec/redoc/v0.md
@@ -12,8 +12,8 @@ hide:
 
 <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
 <script>
-  const SPEC_URL = '../api/gtrack-v0.yaml';
+  const SPEC_URL = 'spec/api/gtrack-v0.yaml';
   Redoc.init(SPEC_URL, { expandResponses: "200,201,204" }, document.getElementById('redoc-v0'));
 </script>
 
-[Скачать YAML](../api/gtrack-v0.yaml)
+[Скачать YAML](spec/api/gtrack-v0.yaml)

--- a/docs/spec/redoc/v1.md
+++ b/docs/spec/redoc/v1.md
@@ -13,8 +13,8 @@ hide:
 
 <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
 <script>
-  const SPEC_URL = '../api/gtrack-v1.yaml';
+  const SPEC_URL = 'spec/api/gtrack-v1.yaml';
   Redoc.init(SPEC_URL, { expandResponses: "200,201,204" }, document.getElementById('redoc-v1'));
 </script>
 
-[Скачать YAML](../api/gtrack-v1.yaml)
+[Скачать YAML](spec/api/gtrack-v1.yaml)


### PR DESCRIPTION
## Summary
- update ReDoc pages to load OpenAPI specs via root-relative paths that respect Material's base URL

## Testing
- not run (docs change)


------
https://chatgpt.com/codex/tasks/task_e_68d94b189a18832eb95d05af5004527a