### PR TITLE
Fix ReDoc spec URL resolution for MkDocs strict

### DIFF
--- a/docs/spec/redoc/v0.md
+++ b/docs/spec/redoc/v0.md
@@ -12,8 +12,11 @@ hide:
 
 <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
 <script>
-  const SPEC_URL = 'spec/api/gtrack-v0.yaml';
+  // MkDocs strict требует относительный путь от текущего файла:
+  const REL = '../api/gtrack-v0.yaml';
+  // А для рантайма строим абсолютный URL с учётом <base href>:
+  const SPEC_URL = new URL(REL, document.baseURI).toString();
   Redoc.init(SPEC_URL, { expandResponses: "200,201,204" }, document.getElementById('redoc-v0'));
 </script>
 
-[Скачать YAML](spec/api/gtrack-v0.yaml)
+[Скачать YAML](../api/gtrack-v0.yaml)

--- a/docs/spec/redoc/v1.md
+++ b/docs/spec/redoc/v1.md
@@ -13,8 +13,9 @@ hide:
 
 <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
 <script>
-  const SPEC_URL = 'spec/api/gtrack-v1.yaml';
+  const REL = '../api/gtrack-v1.yaml';
+  const SPEC_URL = new URL(REL, document.baseURI).toString();
   Redoc.init(SPEC_URL, { expandResponses: "200,201,204" }, document.getElementById('redoc-v1'));
 </script>
 
-[Скачать YAML](spec/api/gtrack-v1.yaml)
+[Скачать YAML](../api/gtrack-v1.yaml)


### PR DESCRIPTION
## Summary
- update the v0 ReDoc page to derive the spec URL relative to `document.baseURI` while keeping MkDocs strict happy with `../api/`
- make the same ReDoc script and download link adjustments for the v1 draft page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d94d0d615c832eaa22440a61f37b0c