### PR TITLE
Fix ReDoc spec URLs for v0/v1 pages

### DIFF
--- a/docs/spec/redoc/v0.md
+++ b/docs/spec/redoc/v0.md
@@ -12,11 +12,18 @@ hide:
 
 <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
 <script>
-  // MkDocs strict требует относительный путь от текущего файла:
-  const REL = '../api/gtrack-v0.yaml';
-  // А для рантайма строим абсолютный URL с учётом <base href>:
-  const SPEC_URL = new URL(REL, document.baseURI).toString();
+  // Для рантайма нужен путь на два уровня вверх: /spec/api/gtrack-v0.yaml
+  const REL_FOR_REDOC = '../../api/gtrack-v0.yaml';
+  const SPEC_URL = new URL(REL_FOR_REDOC, document.baseURI).toString();
   Redoc.init(SPEC_URL, { expandResponses: "200,201,204" }, document.getElementById('redoc-v0'));
+
+  // Ссылка "Скачать YAML":
+  // В исходнике оставляем ../api/... (mkdocs strict валидирует корректно),
+  // а в рантайме переписываем на абсолютный URL, чтобы браузер не ушёл в /spec/redoc/api/...
+  window.addEventListener('DOMContentLoaded', () => {
+    const a = document.getElementById('dl-v0');
+    if (a) a.href = new URL('../../api/gtrack-v0.yaml', document.baseURI).toString();
+  });
 </script>
 
-[Скачать YAML](../api/gtrack-v0.yaml)
+<a id="dl-v0" href="../api/gtrack-v0.yaml">Скачать YAML</a>

--- a/docs/spec/redoc/v1.md
+++ b/docs/spec/redoc/v1.md
@@ -13,9 +13,13 @@ hide:
 
 <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
 <script>
-  const REL = '../api/gtrack-v1.yaml';
-  const SPEC_URL = new URL(REL, document.baseURI).toString();
+  const REL_FOR_REDOC = '../../api/gtrack-v1.yaml';
+  const SPEC_URL = new URL(REL_FOR_REDOC, document.baseURI).toString();
   Redoc.init(SPEC_URL, { expandResponses: "200,201,204" }, document.getElementById('redoc-v1'));
+  window.addEventListener('DOMContentLoaded', () => {
+    const a = document.getElementById('dl-v1');
+    if (a) a.href = new URL('../../api/gtrack-v1.yaml', document.baseURI).toString();
+  });
 </script>
 
-[Скачать YAML](../api/gtrack-v1.yaml)
+<a id="dl-v1" href="../api/gtrack-v1.yaml">Скачать YAML</a>


### PR DESCRIPTION
## Summary
- update the v0/v1 ReDoc pages to resolve spec URLs against `document.baseURI`
- adjust download links to rewrite to absolute URLs at runtime while keeping MkDocs strict validation satisfied

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d94f2215c0832ea7d6da2f4f6e490a