### PR TITLE
Fix YAML quoting in docs workflows

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -53,7 +53,7 @@ jobs:
         if: steps.guard.outputs.ready == 'true'
         run: python -m mkdocs build --strict
 
-      - name: Skip (no wheelhouse/lock yet)
+      - name: Skip build until offline assets are present
         if: steps.guard.outputs.ready != 'true'
         shell: bash
         env:

--- a/.github/workflows/docs-verify-offline.yml
+++ b/.github/workflows/docs-verify-offline.yml
@@ -39,19 +39,17 @@ jobs:
           python -m pip --version
           python -m pip install --no-index --find-links docs/vendor/wheels -r docs/requirements.lock.txt
 
-      - name: Ensure Import placeholder (strict-safe)
+      - name: "Ensure Import placeholder (strict-safe)"
         if: steps.guard.outputs.ready == 'true'
         run: |
           mkdir -p docs/import
           [ -f docs/import/index.md ] || printf '# Import (autogen)\n\nPlaceholder.\n' > docs/import/index.md
 
-      - name: Lint: forbid absolute links to root (except /spec/api/)
+      - name: "Lint: forbid absolute links to root (except /spec/api/)"
         run: |
           set -e
           echo "Scanning for absolute links…"
-          # Markdown-style: ](/something) except /spec/api/
           BAD_MD=$(grep -RnE '\]\(\/(?!spec\/api\/)' docs || true)
-          # HTML-style: href="/something" except /spec/api/
           BAD_HTML=$(grep -RnE 'href=\"\/(?!spec\/api\/)' docs || true)
           if [ -n "$BAD_MD$BAD_HTML" ]; then
             echo "$BAD_MD"


### PR DESCRIPTION
## Summary
- rename the docs preview skip step to clarify offline asset requirement
- quote colon-containing step names in the offline docs verification workflow and tidy the lint step

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d953682c54832eaf35210a2a879922