### PR TITLE
Fix skip step quoting in docs verify offline workflow

### DIFF
--- a/.github/workflows/docs-verify-offline.yml
+++ b/.github/workflows/docs-verify-offline.yml
@@ -76,4 +76,5 @@ jobs:
 
       - name: Skip build (no wheelhouse/lock)
         if: steps.guard.outputs.ready != 'true'
-        run: echo "Skipping offline build: wheels=${{ steps.guard.outputs.wheel_count }}, lock=${{ steps.guard.outputs.lock_size }}"
+        run: |
+          echo "Skipping offline build: wheels=${{ steps.guard.outputs.wheel_count }} lock=${{ steps.guard.outputs.lock_size }}"


### PR DESCRIPTION
## Summary
- switch the skip step to a block scalar so the log message has both values

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d9557cc524832ea3b0263435865eeb