### PR TITLE
Add CI wrapper workflow for docs check

### DIFF
--- a/.github/workflows/ci-check-docs.yml
+++ b/.github/workflows/ci-check-docs.yml
@@ -1,0 +1,77 @@
+name: CI
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  check-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Detect wheelhouse/lock
+        id: guard
+        run: |
+          WCOUNT=$(ls -1 docs/vendor/wheels/*.whl 2>/dev/null | wc -l | tr -d ' ')
+          LSIZE=$(test -f docs/requirements.lock.txt && wc -c < docs/requirements.lock.txt | tr -d ' ' || echo 0)
+          READY=false; [ "$WCOUNT" -gt 0 ] && [ "$LSIZE" -gt 0 ] && READY=true
+          echo "ready=$READY" >> $GITHUB_OUTPUT
+          echo "wheel_count=$WCOUNT" >> $GITHUB_OUTPUT
+          echo "lock_size=$LSIZE" >> $GITHUB_OUTPUT
+
+      - name: "Offline install (from wheelhouse)"
+        if: steps.guard.outputs.ready == 'true'
+        run: |
+          set -e
+          export PIP_NO_INDEX=1
+          export PIP_FIND_LINKS=docs/vendor/wheels
+          python -m pip --version
+          python -m pip install --no-index --find-links docs/vendor/wheels -r docs/requirements.lock.txt
+
+      - name: "Ensure Import placeholder (strict-safe)"
+        if: steps.guard.outputs.ready == 'true'
+        run: |
+          mkdir -p docs/import
+          [ -f docs/import/index.md ] || printf '# Import (autogen)\n\nPlaceholder.\n' > docs/import/index.md
+
+      - name: "Lint: forbid absolute links to root (except /spec/api/)"
+        run: |
+          set -e
+          BAD_MD=$(grep -RnE '\]\(\/(?!spec\/api\/)' docs || true)
+          BAD_HTML=$(grep -RnE 'href=\"\/(?!spec\/api\/)' docs || true)
+          if [ -n "$BAD_MD$BAD_HTML" ]; then
+            echo "$BAD_MD"
+            echo "$BAD_HTML"
+            echo "::error title=Absolute links to root found::Use relative links instead (../ or spec/api/… allowed)."
+            exit 2
+          fi
+
+      - name: "Lint: Redoc pages must reference ../api in MD and ../../api in JS"
+        run: |
+          set -e
+          for f in docs/spec/redoc/*.md; do
+            [ -f "$f" ] || continue
+            grep -qE '\.\./api/gtrack-.*\.yaml' "$f"  || { echo "::error file=$f::Missing '../api/...' link for MkDocs strict"; exit 2; }
+            grep -qE '\.\./\.\./api/gtrack-.*\.yaml' "$f" || { echo "::error file=$f::Missing '../../api/...' in runtime JS"; exit 2; }
+          done
+
+      - name: Build (strict) and assert spec files exist
+        if: steps.guard.outputs.ready == 'true'
+        run: |
+          python -m mkdocs build --strict
+          test -f site/spec/api/gtrack-v0.yaml || { echo "::error title=Missing::site/spec/api/gtrack-v0.yaml"; exit 2; }
+          test -f site/spec/api/gtrack-v1.yaml || { echo "::error title=Missing::site/spec/api/gtrack-v1.yaml"; exit 2; }
+
+      - name: Skip (no wheelhouse/lock)
+        if: steps.guard.outputs.ready != 'true'
+        run: |
+          echo "Skipping offline build: wheels=${{ steps.guard.outputs.wheel_count }} lock=${{ steps.guard.outputs.lock_size }}"


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that reuses offline build guards and required linting for documentation PRs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d95bbbe56c832e85e68284b239130e