### PR TITLE
Pause docs workflows for manual dispatch

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,12 +1,6 @@
 name: Docs - Deploy
 on:
-  push:
-    branches: [ main ]
-  workflow_dispatch:
-    inputs:
-      reason:
-        description: "Why deploy?"
-        required: false
+  workflow_dispatch: {}
 permissions:
   contents: read
   pages: write

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,10 +1,6 @@
 name: check-docs
 on:
-  pull_request:
-    branches: [ main ]
-  pull_request_target:
-    branches: [ main ]
-    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/.github/workflows/docs-refresh-wheels.yml
+++ b/.github/workflows/docs-refresh-wheels.yml
@@ -6,8 +6,6 @@ on:
         description: "Python version"
         required: false
         default: "3.11"
-  schedule:
-    - cron: "0 6 * * 1"   # каждый понедельник 06:00 UTC
 
 permissions:
   contents: write

--- a/.github/workflows/docs-verify-offline.yml
+++ b/.github/workflows/docs-verify-offline.yml
@@ -1,8 +1,6 @@
 name: Docs - Verify Offline
 on:
-  pull_request:
-    branches: [ main ]
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- switch docs deploy, preview, and offline verify workflows to manual dispatch only
- make the docs refresh wheels workflow manual with optional python input

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e23d9ce7f0832ea5626d2dbedc96d2