### PR TITLE
ci(docs): slim CI + fix here-doc; online fallback; manualize heavy workflows

### DIFF
--- a/.github/workflows/ci-check-docs.yml
+++ b/.github/workflows/ci-check-docs.yml
@@ -1,7 +1,6 @@
 name: CI
 on:
-  pull_request:
-    branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -12,6 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,6 +1,8 @@
 name: Docs - Deploy
 on:
-  workflow_dispatch: {}
+  push:
+    branches:
+      - main
 permissions:
   contents: read
   pages: write
@@ -13,8 +15,6 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    outputs:
-      ready: ${{ steps.guard.outputs.ready }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -23,74 +23,46 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Detect wheelhouse/lock
+      - name: Detect wheelhouse/lock (soft)
         id: guard
         run: |
           WCOUNT=$(ls -1 docs/vendor/wheels/*.whl 2>/dev/null | wc -l | tr -d ' ')
           LSIZE=$(test -f docs/requirements.lock.txt && wc -c < docs/requirements.lock.txt | tr -d ' ' || echo 0)
-          READY=false; [ "$WCOUNT" -gt 0 ] && [ "$LSIZE" -gt 0 ] && READY=true
-          echo "ready=$READY" >> $GITHUB_OUTPUT
           echo "wheel_count=$WCOUNT" >> $GITHUB_OUTPUT
-          echo "lock_size=$LSIZE" >> $GITHUB_OUTPUT
+          echo "lock_size=$LSIZE"   >> $GITHUB_OUTPUT
 
-      - name: Offline install
-        if: steps.guard.outputs.ready == 'true'
-        env:
-          PIP_NO_INDEX: "1"
-          PIP_FIND_LINKS: "docs/vendor/wheels"
-        run: |
-          python -m pip --version
-          python -m pip install --no-index --find-links docs/vendor/wheels -r docs/requirements.lock.txt
+      - name: Upgrade pip tooling
+        run: python -m pip install -U pip wheel
 
-      - name: Ensure Import placeholder (strict-safe)
-        if: steps.guard.outputs.ready == 'true'
+      - name: Install deps (prefer OFFLINE, fallback ONLINE)
         run: |
           set -euo pipefail
-          mkdir -p docs/import
-          # Do nothing if README.md exists (it would conflict with index.md)
-          if [ -f docs/import/README.md ]; then
-            exit 0
-          fi
-          # Create placeholder index only if absent
-          if [ ! -f docs/import/index.md ]; then
-            cat > docs/import/index.md <<'MD'
----
-title: Import (автосинк)
-hide:
-  - toc
----
-
-# Import (автосинк)
-
-Этот раздел наполняется автоматически из `docs/import/`.  
-Как только появятся `.md`/`.yaml`, они попадут в меню (awesome-pages).
-MD
+          if [ "${{ steps.guard.outputs.wheel_count }}" != "0" ] && [ "${{ steps.guard.outputs.lock_size }}" != "0" ]; then
+            echo "Installing from wheelhouse/lock (offline)…"
+            PIP_NO_INDEX=1 PIP_FIND_LINKS="docs/vendor/wheels" \
+            python -m pip install --no-index --find-links=docs/vendor/wheels -r docs/requirements.lock.txt
+          else
+            echo "Offline assets not found → installing ONLINE from docs/requirements.in…"
+            python -m pip install -r docs/requirements.in
           fi
 
-      - name: Lint: no dual import roots
+      - name: Ensure Import placeholder (safe)
         run: |
-          set -e
-          if [ -f docs/import/index.md ] && [ -f docs/import/README.md ]; then
-            echo "::error title=Duplicate import root::Both docs/import/index.md and docs/import/README.md exist. Keep only one."
-            exit 2
-          fi
+          mkdir -p docs/import
+          [ -f docs/import/index.md ] || printf '# Import\n\nAuto-generated placeholder.\n' > docs/import/index.md
 
-      - name: Build (strict)
-        if: steps.guard.outputs.ready == 'true'
-        run: python -m mkdocs build --strict
+      - name: Build docs (non-strict)
+        run: python -m mkdocs build
 
       - name: Setup Pages
-        if: steps.guard.outputs.ready == 'true'
         uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        if: steps.guard.outputs.ready == 'true'
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./site
 
   deploy:
-    if: needs.build.outputs.ready == 'true'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/docs-healthcheck.yml
+++ b/.github/workflows/docs-healthcheck.yml
@@ -1,10 +1,7 @@
 name: Docs Healthcheck
 
 on:
-  schedule:
-    - cron: '0 * * * *'
   workflow_dispatch:
-  pull_request:
 
 jobs:
   healthcheck:

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,6 +1,6 @@
 name: check-docs
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -45,25 +45,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p docs/import
-          # Do nothing if README.md exists (it would conflict with index.md)
-          if [ -f docs/import/README.md ]; then
-            exit 0
-          fi
-          # Create placeholder index only if absent
-          if [ ! -f docs/import/index.md ]; then
-            cat > docs/import/index.md <<'MD'
----
-title: Import (автосинк)
-hide:
-  - toc
----
-
-# Import (автосинк)
-
-Этот раздел наполняется автоматически из `docs/import/`.  
-Как только появятся `.md`/`.yaml`, они попадут в меню (awesome-pages).
-MD
-          fi
+          [ -f docs/import/index.md ] || printf '# Import\n\nAuto-generated placeholder (preview).\n' > docs/import/index.md
 
       - name: Lint: no dual import roots
         run: |

--- a/.github/workflows/docs-refresh-wheels.yml
+++ b/.github/workflows/docs-refresh-wheels.yml
@@ -1,11 +1,6 @@
 name: Docs - Refresh Wheels
 on:
   workflow_dispatch:
-    inputs:
-      python:
-        description: "Python version"
-        required: false
-        default: "3.11"
 
 permissions:
   contents: write

--- a/.github/workflows/docs-repo-discovery.yml
+++ b/.github/workflows/docs-repo-discovery.yml
@@ -1,23 +1,6 @@
 name: Docs – Repo Discovery
 on:
   workflow_dispatch:
-    inputs:
-      owner:
-        description: "Repos owner/org (default: current repo owner)"
-        required: false
-      repos:
-        description: "Comma-separated repo names"
-        required: false
-        default: "gtrack-frontend,gtrack-backend"
-      ref:
-        description: "Branch/tag to inspect (default: default branch)"
-        required: false
-      roadmap_label:
-        description: "Label for roadmap issues"
-        required: false
-        default: "roadmap"
-  schedule:
-    - cron: "11 6 * * 1"  # weekly Mon 06:11 UTC
 
 permissions:
   contents: write

--- a/.github/workflows/docs-verify-offline.yml
+++ b/.github/workflows/docs-verify-offline.yml
@@ -1,6 +1,6 @@
 name: Docs - Verify Offline
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -44,25 +44,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p docs/import
-          # Do nothing if README.md exists (it would conflict with index.md)
-          if [ -f docs/import/README.md ]; then
-            exit 0
-          fi
-          # Create placeholder index only if absent
-          if [ ! -f docs/import/index.md ]; then
-            cat > docs/import/index.md <<'MD'
----
-title: Import (автосинк)
-hide:
-  - toc
----
-
-# Import (автосинк)
-
-Этот раздел наполняется автоматически из `docs/import/`.  
-Как только появятся `.md`/`.yaml`, они попадут в меню (awesome-pages).
-MD
-          fi
+          [ -f docs/import/index.md ] || printf '# Import\n\nAuto-generated placeholder (verify-offline).\n' > docs/import/index.md
 
       - name: Lint: no dual import roots
         run: |

--- a/OPS_CI.md
+++ b/OPS_CI.md
@@ -1,0 +1,4 @@
+# Docs CI (slim mode)
+- Auto: Docs – Deploy on push to main (online install fallback; offline wheelhouse used if present).
+- Manual only: Verify Offline, Refresh Wheels, Repo Discovery, Healthcheck, check-docs.
+- Rationale: stabilize docs CI while iterating; strict/offline guards can be re-enabled later.


### PR DESCRIPTION
## Summary
- slim Docs – Deploy to run on pushes to main with fetch-depth=0, online fallback install, and non-strict build
- switch verify/preview/check-docs/refresh/repo-discovery/healthcheck workflows to manual dispatch and fix the import placeholder bug
- document the new lightweight docs CI approach in OPS_CI.md

## Testing
- not run (workflow updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e24351b6b0832e991a204d2802f18b