### PR TITLE
docs(import): switch Import pages to index.md and update nav + auto-sync targets

### DIFF
--- a/.github/workflows/docs-auto-sync.yml
+++ b/.github/workflows/docs-auto-sync.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Prepare import tree
         run: |
           set -euxo pipefail
-          mkdir -p docs/import/app docs/import/backend
+          mkdir -p docs/import/app docs/import/backend docs/import/frontend
           # Copy only useful formats
           rsync -a --delete --prune-empty-dirs \
             --include="*/" \
@@ -65,6 +65,12 @@ jobs:
             --include="*.png" --include="*.jpg" --include="*.jpeg" --include="*.svg" \
             --exclude="*" \
             src-backend/docs/ docs/import/backend/ || true
+          if [ -f docs/import/backend/README.md ]; then
+            mv -f docs/import/backend/README.md docs/import/backend/index.md
+          fi
+          if [ -f docs/import/frontend/README.md ]; then
+            mv -f docs/import/frontend/README.md docs/import/frontend/index.md
+          fi
           touch docs/import/.keep
 
       - name: Detect changes

--- a/docs/import/backend/index.md
+++ b/docs/import/backend/index.md
@@ -1,0 +1,10 @@
+---
+title: Backend (auto-import)
+hide:
+  - toc
+---
+
+!!! note "Автогенерация"
+    Контент синхронизируется из репозитория **gtrack-backend** (README/CHANGELOG).
+
+_Страница будет заполнена авто-синком._

--- a/docs/import/frontend/index.md
+++ b/docs/import/frontend/index.md
@@ -1,0 +1,10 @@
+---
+title: Frontend (auto-import)
+hide:
+  - toc
+---
+
+!!! note "Автогенерация"
+    Контент синхронизируется из репозитория **gtrack-frontend** (README/CHANGELOG).
+
+_Страница будет заполнена авто-синком._

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,12 +33,8 @@ nav:
       - Deployment: ops/DEPLOYMENT.md
       - Domains & DNS: ops/DOMAINS_DNS.md
   - Import:
-      - Backend:
-          - Overview: import/backend/README.md
-          - Notes: import/backend/_notes/TECH_STACK.md
-      - Frontend:
-          - Overview: import/frontend/README.md
-          - Notes: import/frontend/_notes/TECH_STACK.md
+      - Backend: import/backend/index.md
+      - Frontend: import/frontend/index.md
   - Update Packs:
       - 2025-10-03 — v2.9.0: ops/UPDATE_PACKS/2025-10-03-docs-update-pack-v2.9.0.md
   - Changelog: CHANGELOG.md


### PR DESCRIPTION
## Summary
- add placeholder index pages for backend and frontend import docs
- update mkdocs navigation to point Import section to index.md entries
- adjust auto-sync workflow to place README content into index.md outputs

## Testing
- not run (docs-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e36bf2715c832e986bd56340bae3cc